### PR TITLE
Add Gemini API integration

### DIFF
--- a/src/geminiAnalyzer.js
+++ b/src/geminiAnalyzer.js
@@ -4,14 +4,74 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const GEMINI_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent';
+
+/**
+ * Low level helper to call Gemini API.
+ * @param {string} prompt - Prompt sent to Gemini
+ * @returns {Promise<object>} - Raw JSON response
+ */
+async function callGemini(prompt) {
+  if (!GEMINI_API_KEY) {
+    throw new Error('GEMINI_API_KEY not configured');
+  }
+
+  const response = await fetch(`${GEMINI_URL}?key=${GEMINI_API_KEY}` , {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [
+        {
+          parts: [{ text: prompt }],
+        },
+      ],
+      generationConfig: { temperature: 0.2 },
+    }),
+  });
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`Gemini request failed: ${response.status} ${err}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Extract structured information from Gemini response.
+ * @param {object} raw - Raw JSON response from Gemini
+ * @returns {object}
+ */
+function parseGeminiResponse(raw) {
+  const text = raw?.candidates?.[0]?.content?.parts?.[0]?.text || '';
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    return { raw: text };
+  }
+}
 
 /**
  * Analyze text using Gemini AI.
+ * The API is instructed to return JSON with keys: entities,
+ * concepts, questions and citations.
+ *
  * @param {string} text - Plain text to analyze
  * @returns {Promise<object>} - Analysis result
  */
 export async function analyzeTextWithGemini(text) {
-  // Placeholder for Gemini API call
-  // Replace this with actual HTTP request when SDK is available
-  return { summary: `Analyzed text of length ${text.length}` };
+  const prompt = `Analyze the following text and return JSON with keys: entities, concepts, questions, citations. Text:\n${text}`;
+  const raw = await callGemini(prompt);
+  return parseGeminiResponse(raw);
+}
+
+/**
+ * Placeholder for future advanced analysis steps.
+ * @param {string} _text
+ * @returns {null}
+ */
+export function analyzeForContradictions(_text) {
+  // To be implemented in the future
+  return null;
 }


### PR DESCRIPTION
## Summary
- integrate Gemini API in `geminiAnalyzer.js`
- parse response for entities, concepts, questions, and citations
- add placeholder helper `analyzeForContradictions`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853984328408326a3d12b3a3284a4d9