### PR TITLE
Update ingest API and add CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,14 @@ Cellula primaria di Gihary IA – un sistema modulare e auto-evolutivo basato su
 The `src/debugger.js` module now provides advanced logging utilities. Call
 `setupDebugger({ verbose: true })` to enable console output and use
 `logState`, `logError` and `captureVar` to record information to `debug.log`.
+
+## Ingestion endpoint
+
+POST `/gihary-ingest` expects a JSON body with the following fields:
+
+- `input`: the text to ingest
+- `type`: the source type (`email`, `whatsapp`, `file` or `clipboard`)
+- `userId` *(optional)*: identifier used when persisting data
+
+The response will contain `{ success: true, data }` on success or
+`{ success: false, error }` if something went wrong.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "dotenv": "^16.3.1",
-    "firebase-admin": "^11.10.1"
+    "firebase-admin": "^11.10.1",
+    "cors": "^2.8.5"
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,24 +1,32 @@
 // Minimal Express server exposing the ingestion endpoint
 import express from 'express';
+import cors from 'cors';
 import dotenv from 'dotenv';
 import { ingestText } from './ingestor.js';
+import { logEvent } from './logger.js';
 
 dotenv.config();
 
 const app = express();
 app.use(express.json());
+app.use(cors());
 
 app.post('/gihary-ingest', async (req, res) => {
-  const { userId, source, text } = req.body;
-  if (!userId || !source || !text) {
-    return res.status(400).json({ error: 'Missing parameters' });
+  const { input, type, userId = 'anonymous' } = req.body;
+  if (!input || !type) {
+    return res
+      .status(400)
+      .json({ success: false, error: 'Missing parameters' });
   }
 
   try {
-    const result = await ingestText(userId, source, text);
-    res.json({ result });
+    logEvent('api.request', { userId, type });
+    const data = await ingestText(userId, type, input);
+    logEvent('api.success', { userId, type });
+    res.json({ success: true, data });
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    logEvent('api.error', { userId, type, message: err.message });
+    res.status(500).json({ success: false, error: err.message });
   }
 });
 


### PR DESCRIPTION
## Summary
- allow cross-origin requests
- accept `{input, type, userId}` on `/gihary-ingest`
- log API usage and return structured results
- document the new endpoint

## Testing
- `node --check src/server.js`

------
https://chatgpt.com/codex/tasks/task_e_68539ca10ba88326bd474df401d94380