### PR TITLE
Implement backup storage and rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ Cellula primaria di Gihary IA – un sistema modulare e auto-evolutivo basato su
 The `src/debugger.js` module now provides advanced logging utilities. Call
 `setupDebugger({ verbose: true })` to enable console output and use
 `logState`, `logError` and `captureVar` to record information to `debug.log`.
+
+## Persistence and Rollback
+
+`saveToCore` stores data in Firestore and now creates timestamped backups under
+`core/{userId}/entries`. Use `rollbackMemory(userId, timestamp)` to restore the
+entry closest to a given moment in time. Hooks for future diff/compare features
+are included in `rollback.js`.

--- a/src/core.js
+++ b/src/core.js
@@ -20,4 +20,11 @@ const db = getFirestore(app);
  */
 export async function saveToCore(userId, payload) {
   await db.collection('core').doc(userId).set(payload, { merge: true });
+
+  // Also keep a timestamped backup entry for rollback
+  const entry = {
+    timestamp: new Date().toISOString(),
+    data: payload,
+  };
+  await db.collection('core').doc(userId).collection('entries').add(entry);
 }

--- a/src/rollback.js
+++ b/src/rollback.js
@@ -4,14 +4,34 @@ import { getFirestore } from 'firebase-admin/firestore';
 const db = getFirestore();
 
 /**
- * Restore previous data snapshot for a user.
+ * Restore previous data snapshot for a user closest to the given timestamp.
  * @param {string} userId - Unique identifier of the user
+ * @param {string|Date} timestamp - Target timestamp
  * @returns {Promise<object|null>} - Restored data or null
  */
-export async function rollbackMemory(userId) {
-  const snapshot = await db.collection('core').doc(userId).get();
-  if (!snapshot.exists) return null;
-  const data = snapshot.data();
-  // Additional rollback logic would go here
-  return data;
+export async function rollbackMemory(userId, timestamp) {
+  const entriesRef = db.collection('core').doc(userId).collection('entries');
+  const entriesSnap = await entriesRef.orderBy('timestamp').get();
+  if (entriesSnap.empty) return null;
+
+  const target = timestamp ? new Date(timestamp).getTime() : Date.now();
+  let closest = null;
+  let minDiff = Infinity;
+  entriesSnap.forEach((doc) => {
+    const entry = doc.data();
+    const ts = new Date(entry.timestamp).getTime();
+    const diff = Math.abs(ts - target);
+    if (diff < minDiff) {
+      minDiff = diff;
+      closest = entry;
+    }
+  });
+
+  return closest ? closest.data : null;
+}
+
+// Placeholder for future diff/compare utilities
+export function diffEntries(oldEntry, newEntry) {
+  // TODO: Implement diff logic
+  return {};
 }


### PR DESCRIPTION
## Summary
- persist timestamped backup entries under `core/{userId}/entries`
- allow rollback to entry closest to a timestamp
- document persistence and rollback features

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68539ca57e0c8326840cece580b0e905