### PR TITLE
Add structured WhatsApp and Gmail parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,20 @@ Il modulo `src/ranker.js` calcola un punteggio da 1 a 10, pesando **rilevanza, n
 
 La funzione `trainRankingModel` è attualmente un placeholder per un futuro addestramento dinamico dei pesi.
 
+## Parsing examples
+
+Le funzioni di parsing normalizzano i messaggi in un array di oggetti con i campi:
+`sender`, `text`, `timestamp`, `channel` e `language`.
+
+```javascript
+import { parseWhatsappMessage } from './src/parser/whatsappParser.js';
+import { parseEmail } from './src/parser/emailParser.js';
+
+const chat = '12/03/24, 15:22 - Alice: Ciao!\n12/03/24, 15:23 - Bob: Benvenuta';
+const messages = parseWhatsappMessage(chat);
+// [ { sender: 'Alice', text: 'Ciao!', channel: 'whatsapp', ... }, ... ]
+
+const mail = `From: Alice <alice@example.com>\nDate: Tue, 3 Oct 2023 10:15:00 +0200\n\nHello world`;
+const emails = parseEmail(mail);
+```
+

--- a/src/parser/emailParser.js
+++ b/src/parser/emailParser.js
@@ -1,11 +1,34 @@
 // Email parsing utilities
 
 /**
- * Extract meaningful text from a raw email string.
+ * Parse raw email or Gmail export into structured messages.
+ *
+ * Supported formats include full RFC822 messages as well as text
+ * copied from Gmail where headers start with `From:` and `Date:`.
+ *
  * @param {string} raw - Raw email content
- * @returns {string} - Parsed text
+ * @returns {Array<{sender:string,text:string,timestamp:string|null,channel:string,language:string}>}
  */
 export function parseEmail(raw) {
-  // Simplistic placeholder implementation
-  return raw.replace(/\n+/g, ' ').trim();
+  const blocks = raw.split(/\n(?=From:\s)/);
+  const messages = [];
+
+  for (const block of blocks) {
+    const senderMatch = block.match(/^From:\s*(.+)$/m);
+    const dateMatch = block.match(/^Date:\s*(.+)$/m);
+    const body = block.split(/\r?\n\r?\n/).slice(1).join('\n').trim();
+    const ts = dateMatch ? new Date(dateMatch[1].trim()) : null;
+
+    if (senderMatch || body) {
+      messages.push({
+        sender: senderMatch ? senderMatch[1].trim() : '',
+        text: body,
+        timestamp: ts && !isNaN(ts) ? ts.toISOString() : null,
+        channel: 'email',
+        language: 'unknown',
+      });
+    }
+  }
+
+  return messages;
 }

--- a/src/parser/whatsappParser.js
+++ b/src/parser/whatsappParser.js
@@ -1,11 +1,40 @@
 // WhatsApp message parsing utilities
 
 /**
- * Parse a WhatsApp message string.
- * @param {string} raw - Raw message text
- * @returns {string} - Parsed message
+ * Parse exported WhatsApp chat text.
+ *
+ * Typical export lines look like:
+ * `12/03/24, 15:22 - Alice: Hello world`
+ * `[12/03/24, 15:22:11] Bob: Hi!`
+ *
+ * The parser returns an array of objects with sender, text,
+ * timestamp, channel and language fields.
+ *
+ * @param {string} raw - Raw WhatsApp export
+ * @returns {Array<{sender:string,text:string,timestamp:string|null,channel:string,language:string}>}
  */
 export function parseWhatsappMessage(raw) {
-  // Placeholder: remove timestamps or metadata if any
-  return raw.replace(/\[[^\]]*\]/g, '').trim();
+  const lines = raw.split(/\r?\n/);
+  const messages = [];
+  const pattern = /^(?:\[)?(\d{1,2}[\/\-]\d{1,2}[\/\-]\d{2,4}),?\s+(\d{1,2}:\d{2}(?::\d{2})?(?:\s?[AP]M)?)\]?\s*(?:-|–)\s*([^:]+):\s*(.*)$/;
+
+  for (const line of lines) {
+    const match = line.match(pattern);
+    if (match) {
+      const [, date, time, sender, text] = match;
+      const dateTime = `${date} ${time}`;
+      const ts = new Date(dateTime);
+      messages.push({
+        sender: sender.trim(),
+        text: text.trim(),
+        timestamp: isNaN(ts) ? null : ts.toISOString(),
+        channel: 'whatsapp',
+        language: 'unknown',
+      });
+    } else if (messages.length > 0) {
+      messages[messages.length - 1].text += `\n${line.trim()}`;
+    }
+  }
+
+  return messages;
 }


### PR DESCRIPTION
## Summary
- return structured array of messages from whatsappParser and emailParser
- document parsing utilities and examples

## Testing
- `npx -y jest` *(fails: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_6853cdd825608326a84d395b38486ad4