### PR TITLE
Implement local backup after Firestore writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ La risposta conterrà `{ success: true, data }` in caso di successo, oppure `{ s
 
 La funzione `saveToCore` salva i dati principali su Firestore e crea **backup con timestamp** nella struttura:
 
+Inoltre, dopo ogni scrittura viene creata/aggiornata la cartella `core/{userId}/entries` e il `payload` viene salvato in `YYYY-MM-DD.json`.
+
 
 È possibile ripristinare uno stato precedente con `rollbackMemory(userId, timestamp)`, che recupera l’entry più vicina nel tempo.
 

--- a/src/core.js
+++ b/src/core.js
@@ -2,6 +2,8 @@
 import { initializeApp, applicationDefault } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
 
 dotenv.config();
 
@@ -27,4 +29,10 @@ export async function saveToCore(userId, payload) {
     data: payload,
   };
   await db.collection('core').doc(userId).collection('entries').add(entry);
+
+  // Persist a local copy in core/{userId}/entries/YYYY-MM-DD.json
+  const dir = path.join('core', userId, 'entries');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = new Date().toISOString().slice(0, 10) + '.json';
+  fs.writeFileSync(path.join(dir, file), JSON.stringify(payload, null, 2));
 }


### PR DESCRIPTION
## Summary
- keep a local copy of payloads in `core/{userId}/entries/YYYY-MM-DD.json`
- document how the new local backup works

## Testing
- `npx jest` *(fails: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_6853d0e7956483269a489a54d372bbe9