### PR TITLE
Add ignore patterns for debug log and backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
+debug.log
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
@@ -134,3 +135,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+core/


### PR DESCRIPTION
## Summary
- ignore `debug.log`
- ignore local `core/` backup directory

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6854541a62b08326b81a82218631f848