### PR TITLE
Add basic module tests

### DIFF
--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1,3 +1,5 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import * as core from '../src/core.js';
+
+test('exports saveToCore function', () => {
+  expect(typeof core.saveToCore).toBe('function');
 });

--- a/test/debugger.test.js
+++ b/test/debugger.test.js
@@ -1,3 +1,7 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import { setVerbose, toggleSilent } from '../src/debugger.js';
+
+test('toggleSilent toggles verbosity', () => {
+  setVerbose(false);
+  const result = toggleSilent();
+  expect(result).toBe(true);
 });

--- a/test/emailParser.test.js
+++ b/test/emailParser.test.js
@@ -1,3 +1,8 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import { parseEmail } from '../src/parser/emailParser.js';
+
+test('parseEmail returns array with sender', () => {
+  const raw = 'From: Bob\nDate: Wed, 1 Jan 2020 10:00:00 +0000\n\nHello';
+  const result = parseEmail(raw);
+  expect(Array.isArray(result)).toBe(true);
+  expect(result[0].sender).toBe('Bob');
 });

--- a/test/fileParser.test.js
+++ b/test/fileParser.test.js
@@ -1,3 +1,9 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import fs from 'fs';
+import { parseTextFile } from '../src/parser/fileParser.js';
+
+test('parseTextFile reads file contents', () => {
+  const tmp = 'tmp_test.txt';
+  fs.writeFileSync(tmp, 'hello');
+  expect(parseTextFile(tmp)).toBe('hello');
+  fs.unlinkSync(tmp);
 });

--- a/test/geminiAnalyzer.test.js
+++ b/test/geminiAnalyzer.test.js
@@ -1,3 +1,5 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import { analyzeForContradictions } from '../src/geminiAnalyzer.js';
+
+test('analyzeForContradictions returns null', () => {
+  expect(analyzeForContradictions('text')).toBeNull();
 });

--- a/test/ingestor.test.js
+++ b/test/ingestor.test.js
@@ -1,3 +1,5 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import { ingestText } from '../src/ingestor.js';
+
+test('rejects unknown source type', async () => {
+  await expect(ingestText('u', 'unknown', 'text')).rejects.toThrow('Unknown source type');
 });

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,3 +1,13 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import fs from 'fs';
+import { logEvent } from '../src/logger.js';
+
+const logFile = 'gihary.log';
+
+afterEach(() => {
+  if (fs.existsSync(logFile)) fs.unlinkSync(logFile);
+});
+
+test('logEvent creates log file', () => {
+  logEvent('test', { ok: true });
+  expect(fs.existsSync(logFile)).toBe(true);
 });

--- a/test/meta.test.js
+++ b/test/meta.test.js
@@ -1,3 +1,6 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import { suggestAgentIfNeeded } from '../src/meta.js';
+
+test('suggestAgentIfNeeded detects action need', () => {
+  const result = suggestAgentIfNeeded({ summary: 'We should take action now' });
+  expect(result).toBe('action-agent');
 });

--- a/test/ranker.test.js
+++ b/test/ranker.test.js
@@ -1,3 +1,7 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import { evaluateRelevance } from '../src/ranker.js';
+
+test('evaluateRelevance returns value 1-10', () => {
+  const score = evaluateRelevance({ entities: [], concepts: [], questions: [] });
+  expect(score).toBeGreaterThanOrEqual(1);
+  expect(score).toBeLessThanOrEqual(10);
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,3 +1,0 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
-});

--- a/test/whatsappParser.test.js
+++ b/test/whatsappParser.test.js
@@ -1,3 +1,8 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import { parseWhatsappMessage } from '../src/parser/whatsappParser.js';
+
+test('parseWhatsappMessage returns array with sender', () => {
+  const raw = '12/03/24, 15:22 - Alice: Hello';
+  const result = parseWhatsappMessage(raw);
+  expect(Array.isArray(result)).toBe(true);
+  expect(result[0].sender).toBe('Alice');
 });


### PR DESCRIPTION
## Summary
- implement simple assertions across test files
- remove unused server test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685454bbc1888326a1678a92bdbbc558