### PR TITLE
Make parseTextFile asynchronous

### DIFF
--- a/src/ingestor.js
+++ b/src/ingestor.js
@@ -32,7 +32,7 @@ export async function ingestText(userId, source, raw, options = {}) {
       logEvent('ingest.parse', { userId, source: 'whatsapp' });
       break;
     case 'file':
-      parsed = parseTextFile(raw);
+      parsed = await parseTextFile(raw);
       logEvent('ingest.parse', { userId, source: 'file' });
       break;
     case 'clipboard':

--- a/src/parser/fileParser.js
+++ b/src/parser/fileParser.js
@@ -4,8 +4,8 @@ import fs from 'fs';
 /**
  * Read and return text from a file path.
  * @param {string} path - File system path
- * @returns {string} - File contents
- */
-export function parseTextFile(path) {
-  return fs.readFileSync(path, 'utf-8');
+ * @returns {Promise<string>} - File contents
+*/
+export async function parseTextFile(path) {
+  return await fs.promises.readFile(path, 'utf-8');
 }

--- a/test/fileParser.test.js
+++ b/test/fileParser.test.js
@@ -1,9 +1,10 @@
 import fs from 'fs';
 import { parseTextFile } from '../src/parser/fileParser.js';
 
-test('parseTextFile reads file contents', () => {
+test('parseTextFile reads file contents', async () => {
   const tmp = 'tmp_test.txt';
   fs.writeFileSync(tmp, 'hello');
-  expect(parseTextFile(tmp)).toBe('hello');
+  const content = await parseTextFile(tmp);
+  expect(content).toBe('hello');
   fs.unlinkSync(tmp);
 });


### PR DESCRIPTION
## Summary
- use `fs.promises.readFile` in `parseTextFile`
- await `parseTextFile` in `ingestor`
- adapt file parser test to async behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545b77c6fc8326826424c990808234