### PR TITLE
Implement analyzeForContradictions

### DIFF
--- a/src/geminiAnalyzer.js
+++ b/src/geminiAnalyzer.js
@@ -71,7 +71,20 @@ export async function analyzeTextWithGemini(text) {
  * @param {string} _text
  * @returns {null}
  */
-export function analyzeForContradictions(_text) {
-  // To be implemented in the future
-  return null;
+export async function analyzeForContradictions(text) {
+  const prompt =
+    `Identify contradictions, logical inconsistencies or dubious claims in the following text. ` +
+    `Respond ONLY with JSON in the form {"contradictions": ["..."]}. ` +
+    `Return an empty array if none are found.\nText:\n${text}`;
+
+  try {
+    const raw = await callGemini(prompt);
+    const parsed = parseGeminiResponse(raw);
+    const contradictions = Array.isArray(parsed?.contradictions)
+      ? parsed.contradictions
+      : [];
+    return { success: true, contradictions };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
 }

--- a/test/geminiAnalyzer.test.js
+++ b/test/geminiAnalyzer.test.js
@@ -1,5 +1,12 @@
-import { analyzeForContradictions } from '../src/geminiAnalyzer.js';
+let analyzeForContradictions;
 
-test('analyzeForContradictions returns null', () => {
-  expect(analyzeForContradictions('text')).toBeNull();
+beforeAll(async () => {
+  delete process.env.GEMINI_API_KEY;
+  ({ analyzeForContradictions } = await import('../src/geminiAnalyzer.js'));
+});
+
+test('returns error when API key is missing', async () => {
+  const result = await analyzeForContradictions('text');
+  expect(result.success).toBe(false);
+  expect(result.error).toMatch(/GEMINI_API_KEY/);
 });


### PR DESCRIPTION
## Summary
- make Gemini-based analysis work in `analyzeForContradictions`
- update tests to cover missing API key scenario

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545cfc990483268c69da48dcbf59cd