### PR TITLE
Add ranking model implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Il modulo `rollback.js` include anche **hook per funzionalità future di confron
 
 Il modulo `src/ranker.js` calcola un punteggio da 1 a 10, pesando **rilevanza, novità, contesto personale e applicabilità futura**.
 
-La funzione `trainRankingModel` è attualmente un placeholder per un futuro addestramento dinamico dei pesi.
+La funzione `trainRankingModel` valuta ora un singolo `entry` e restituisce un oggetto
+con punteggio e breakdown dei quattro criteri, utilizzando pesi di default
+`0.4`, `0.3`, `0.2` e `0.1`.
 
 ## Parsing examples
 

--- a/src/ranker.js
+++ b/src/ranker.js
@@ -4,9 +4,9 @@
 // tuned in the future to adjust how much each aspect contributes to the
 // final score. The weights should sum roughly to 1.
 const RELEVANCE_WEIGHT = 0.4;
-const NOVELTY_WEIGHT = 0.2;
+const NOVELTY_WEIGHT = 0.3;
 const PERSONAL_CONTEXT_WEIGHT = 0.2;
-const FUTURE_APPLICABILITY_WEIGHT = 0.2;
+const FUTURE_APPLICABILITY_WEIGHT = 0.1;
 
 /**
  * Evaluate the relevance of the analyzed text using simple heuristics.
@@ -34,12 +34,73 @@ export function evaluateRelevance(analysis) {
 }
 
 /**
- * Placeholder for a future ranking model training routine. It currently does
- * nothing but can be expanded to update the weighting factors or to learn a
- * model from labeled data.
+ * Analyze an entry and compute a weighted ranking score. This is a very
+ * lightweight implementation that relies on simple heuristics for relevance,
+ * novelty, personal context and future applicability.
  *
- * @param {Array<object>} _dataset - Training data
+ * @param {{ text: string }} entry - Entry to evaluate
+ * @param {object} [options]
+ * @param {Array<string>} [options.pastEntries] - Previous texts for novelty
+ * @param {Array<string>} [options.personalKeywords] - User keywords
+ * @returns {{ score:number, breakdown:{relevance:number,novelty:number,personalContext:number,futureValue:number} }}
  */
-export function trainRankingModel(_dataset) {
-  // To be implemented in the future
+export function trainRankingModel(entry = {}, options = {}) {
+  const { pastEntries = [], personalKeywords = [] } = options;
+  const text = (entry.text || '').toString();
+
+  const relevance = calculateRelevance(text);
+  const novelty = estimateNovelty(text, pastEntries);
+  const personalContext = detectPersonalContext(text, personalKeywords);
+  const futureValue = detectFutureValue(text);
+
+  const weighted =
+    (relevance / 10) * RELEVANCE_WEIGHT +
+    (novelty / 10) * NOVELTY_WEIGHT +
+    (personalContext / 10) * PERSONAL_CONTEXT_WEIGHT +
+    (futureValue / 10) * FUTURE_APPLICABILITY_WEIGHT;
+
+  return {
+    score: Number((weighted * 10).toFixed(1)),
+    breakdown: { relevance, novelty, personalContext, futureValue },
+  };
+}
+
+function calculateRelevance(text) {
+  const words = text.split(/\s+/).filter(Boolean);
+  const unique = new Set(words.map((w) => w.toLowerCase())).size;
+  if (!words.length) return 1;
+  const density = unique / words.length;
+  return clamp(Math.round(density * 10), 1, 10);
+}
+
+function estimateNovelty(text, pastEntries) {
+  if (!pastEntries || pastEntries.length === 0) return 10;
+  const sims = pastEntries.map((p) => jaccardSimilarity(text, p));
+  const avg = sims.reduce((a, b) => a + b, 0) / sims.length;
+  return clamp(Math.round((1 - avg) * 10), 1, 10);
+}
+
+function detectPersonalContext(text, keywords) {
+  if (!keywords || keywords.length === 0) return 1;
+  const lower = text.toLowerCase();
+  const found = keywords.filter((k) => lower.includes(k.toLowerCase())).length;
+  const ratio = found / keywords.length;
+  return clamp(Math.round(ratio * 10) || 1, 1, 10);
+}
+
+function detectFutureValue(text) {
+  const matches = text.match(/\b(will|shall|going to|devo|andr[oà]|prenoter[oà]|dovr[oà]|far[oà])\b/gi) || [];
+  return clamp(matches.length + 1, 1, 10);
+}
+
+function jaccardSimilarity(a, b) {
+  const setA = new Set(a.toLowerCase().split(/\W+/).filter(Boolean));
+  const setB = new Set(b.toLowerCase().split(/\W+/).filter(Boolean));
+  const intersection = [...setA].filter((w) => setB.has(w));
+  const union = new Set([...setA, ...setB]);
+  return union.size === 0 ? 0 : intersection.length / union.size;
+}
+
+function clamp(num, min, max) {
+  return Math.min(max, Math.max(min, num));
 }

--- a/test/ranker.test.js
+++ b/test/ranker.test.js
@@ -1,7 +1,22 @@
-import { evaluateRelevance } from '../src/ranker.js';
+import { evaluateRelevance, trainRankingModel } from '../src/ranker.js';
 
 test('evaluateRelevance returns value 1-10', () => {
   const score = evaluateRelevance({ entities: [], concepts: [], questions: [] });
   expect(score).toBeGreaterThanOrEqual(1);
   expect(score).toBeLessThanOrEqual(10);
+});
+
+test('trainRankingModel returns structured score', () => {
+  const result = trainRankingModel({ text: 'Andr\u00f2 a Roma con Luca' }, {
+    pastEntries: ['I was in Milan last year'],
+    personalKeywords: ['Luca', 'Roma'],
+  });
+  expect(result).toHaveProperty('score');
+  expect(result).toHaveProperty('breakdown');
+  expect(result.breakdown).toHaveProperty('relevance');
+  expect(result.breakdown).toHaveProperty('novelty');
+  expect(result.breakdown).toHaveProperty('personalContext');
+  expect(result.breakdown).toHaveProperty('futureValue');
+  expect(result.score).toBeGreaterThanOrEqual(1);
+  expect(result.score).toBeLessThanOrEqual(10);
 });


### PR DESCRIPTION
## Summary
- implement `trainRankingModel` with simple heuristics
- adjust ranking weights
- document ranking model usage
- add unit test for the new function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857e0bb403483268610f9fc5a8134d4