### PR TITLE
Enhance agent suggestion logic

### DIFF
--- a/src/meta.js
+++ b/src/meta.js
@@ -2,12 +2,27 @@
 
 /**
  * Suggest an additional agent based on analysis if required.
+ *
+ * A suggestion is made when the provided relevance score is higher than a
+ * predefined threshold and at least one of the supplied keywords is detected
+ * in the analysis summary. Keyword matching is case-insensitive.
+ *
  * @param {object} analysis - Analysis result
+ * @param {number} relevanceScore - Computed relevance of the analysis
+ * @param {Array<string>} keywords - List of keywords to look for
  * @returns {string|null} - Suggested agent name or null
  */
-export function suggestAgentIfNeeded(analysis) {
-  if (analysis.summary && analysis.summary.includes('action')) {
+export function suggestAgentIfNeeded(analysis, relevanceScore = 0, keywords = []) {
+  const RELEVANCE_THRESHOLD = 7;
+  const summary = (analysis.summary || '').toLowerCase();
+
+  const keywordMatch = Array.isArray(keywords)
+    ? keywords.some((k) => summary.includes(k.toLowerCase()))
+    : false;
+
+  if (relevanceScore > RELEVANCE_THRESHOLD && keywordMatch) {
     return 'action-agent';
   }
+
   return null;
 }

--- a/test/meta.test.js
+++ b/test/meta.test.js
@@ -1,6 +1,16 @@
 import { suggestAgentIfNeeded } from '../src/meta.js';
 
-test('suggestAgentIfNeeded detects action need', () => {
-  const result = suggestAgentIfNeeded({ summary: 'We should take action now' });
+test('suggestAgentIfNeeded returns null when relevance below threshold', () => {
+  const result = suggestAgentIfNeeded({ summary: 'We should take action now' }, 5, ['action']);
+  expect(result).toBeNull();
+});
+
+test('suggestAgentIfNeeded returns null when keywords do not match', () => {
+  const result = suggestAgentIfNeeded({ summary: 'We should take action now' }, 8, ['different']);
+  expect(result).toBeNull();
+});
+
+test('suggestAgentIfNeeded suggests agent when relevance and keyword match', () => {
+  const result = suggestAgentIfNeeded({ summary: 'We should take action now' }, 8, ['action']);
   expect(result).toBe('action-agent');
 });


### PR DESCRIPTION
## Summary
- expand `suggestAgentIfNeeded` to consider a relevance score and keyword list
- add tests verifying relevance threshold and keyword matching logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857efd6d3c08326b1866b078a13db96