### PR TITLE
Add ranking breakdown and agent queue

### DIFF
--- a/src/agentQueue.js
+++ b/src/agentQueue.js
@@ -1,0 +1,14 @@
+const queue = [];
+
+export function enqueueAgent(name) {
+  queue.push({ name, timestamp: new Date().toISOString() });
+}
+
+export function getAgentQueue() {
+  return queue;
+}
+
+export function clearAgentQueue() {
+  queue.length = 0;
+}
+

--- a/src/gihary-loop.js
+++ b/src/gihary-loop.js
@@ -1,8 +1,9 @@
 // Decision loop handling actions after text analysis
-import { evaluateRelevance } from './ranker.js';
+import { trainRankingModel } from './ranker.js';
 import { suggestAgentIfNeeded } from './meta.js';
 import { saveToCore } from './core.js';
 import { logEvent } from './logger.js';
+import { enqueueAgent } from './agentQueue.js';
 
 /**
  * Decide how to handle analyzed data.
@@ -10,28 +11,52 @@ import { logEvent } from './logger.js';
  * the data, trigger a response or send a notification.
  *
  * @param {{ userId: string, source: string, parsed: any, analysis: object }} data
- * @returns {Promise<{score:number,suggestedAgents:Array<string>,shouldSave:boolean,shouldRespond:boolean,shouldNotify:boolean}>}
+ * @returns {Promise<{score:number,scoreBreakdown:object,suggestedAgents:Array<string>,shouldSave:boolean,shouldRespond:boolean,shouldNotify:boolean}>}
  */
 export async function processIncoming(data) {
   const { userId, source, parsed, analysis } = data;
-  const score = evaluateRelevance(analysis);
-  const suggested = suggestAgentIfNeeded(analysis);
+  const text = Array.isArray(parsed)
+    ? parsed.map((m) => m.text).join('\n')
+    : String(parsed ?? '');
+  const { score, breakdown: scoreBreakdown } = trainRankingModel({ text });
+  const suggested = suggestAgentIfNeeded(analysis, score);
   const suggestedAgents = suggested ? [suggested] : [];
+  suggestedAgents.forEach(enqueueAgent);
 
   const shouldSave = score >= 5;
   const shouldRespond = Boolean(suggested);
   const shouldNotify = score >= 8;
 
   if (shouldSave) {
-    await saveToCore(userId, { source, parsed, analysis, score, suggestedAgents });
-    logEvent('loop.save', { userId, source, score });
+    await saveToCore(userId, {
+      source,
+      parsed,
+      analysis,
+      score,
+      scoreBreakdown,
+      suggestedAgents,
+    });
+    logEvent('loop.save', {
+      userId,
+      source,
+      score,
+      scoreBreakdown,
+      agents: suggestedAgents,
+    });
   }
   if (shouldRespond) {
-    logEvent('loop.respond', { userId, source, agent: suggested });
+    logEvent('loop.respond', { userId, source, agents: suggestedAgents });
   }
   if (shouldNotify) {
-    logEvent('loop.notify', { userId, source, score });
+    logEvent('loop.notify', { userId, source, score, scoreBreakdown });
   }
 
-  return { score, suggestedAgents, shouldSave, shouldRespond, shouldNotify };
+  return {
+    score,
+    scoreBreakdown,
+    suggestedAgents,
+    shouldSave,
+    shouldRespond,
+    shouldNotify,
+  };
 }

--- a/src/ingestor.js
+++ b/src/ingestor.js
@@ -62,12 +62,14 @@ export async function ingestText(userId, source, raw, options = {}) {
       userId,
       source,
       score: loopResult.score,
+      scoreBreakdown: loopResult.scoreBreakdown,
       suggestedAgents: loopResult.suggestedAgents,
     });
 
     return {
       analysis,
       score: loopResult.score,
+      scoreBreakdown: loopResult.scoreBreakdown,
       suggestedAgents: loopResult.suggestedAgents,
     };
   } catch (error) {

--- a/test/agentQueue.test.js
+++ b/test/agentQueue.test.js
@@ -1,0 +1,13 @@
+import { enqueueAgent, getAgentQueue, clearAgentQueue } from '../src/agentQueue.js';
+
+afterEach(() => {
+  clearAgentQueue();
+});
+
+test('enqueueAgent adds agent to queue', () => {
+  enqueueAgent('test-agent');
+  const q = getAgentQueue();
+  expect(q.length).toBe(1);
+  expect(q[0].name).toBe('test-agent');
+});
+

--- a/test/gihary-loop.test.js
+++ b/test/gihary-loop.test.js
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import { jest } from '@jest/globals';
+
+let processIncoming;
+let getAgentQueue;
+let clearAgentQueue;
+
+beforeEach(async () => {
+  jest.resetModules();
+  jest.unstable_mockModule('../src/core.js', () => ({
+    saveToCore: jest.fn().mockResolvedValue(undefined),
+  }));
+  jest.unstable_mockModule('../src/meta.js', () => ({
+    suggestAgentIfNeeded: () => 'test-agent',
+  }));
+  ({ getAgentQueue, clearAgentQueue } = await import('../src/agentQueue.js'));
+  ({ processIncoming } = await import('../src/gihary-loop.js'));
+});
+
+afterEach(() => {
+  if (fs.existsSync('gihary.log')) fs.unlinkSync('gihary.log');
+  clearAgentQueue();
+  jest.resetModules();
+});
+
+test('processIncoming returns breakdown, enqueues agents and logs details', async () => {
+  // sanity check
+  const { logEvent } = await import('../src/logger.js');
+  logEvent('pretest', {});
+  const result = await processIncoming({
+    userId: 'u',
+    source: 'test',
+    parsed: 'Andr\u00f2 a Roma con Luca',
+    analysis: { summary: 'Take action' },
+  });
+  expect(result).toHaveProperty('scoreBreakdown');
+  expect(result.suggestedAgents).toEqual(['test-agent']);
+  expect(getAgentQueue().length).toBe(1);
+
+  if (fs.existsSync('gihary.log')) {
+    const lines = fs.readFileSync('gihary.log', 'utf-8').trim().split('\n');
+    const saveEntry = lines.map(JSON.parse).find(e => e.type === 'loop.save');
+    expect(saveEntry).toBeDefined();
+    expect(saveEntry.data.scoreBreakdown).toBeDefined();
+    expect(saveEntry.data.agents).toContain('test-agent');
+  } else {
+    throw new Error('log file missing');
+  }
+});
+


### PR DESCRIPTION
## Summary
- compute ranking scores with `trainRankingModel` and include breakdown
- queue suggested agents via new `enqueueAgent` helper
- log score breakdown and agents in `processIncoming`
- propagate breakdown through ingest pipeline
- add unit tests for new queue and loop logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857f071dc448326959b8e7600191bdd