### PR TITLE
Complete diffEntries function

### DIFF
--- a/src/rollback.js
+++ b/src/rollback.js
@@ -43,18 +43,21 @@ export async function rollbackMemory(userId, timestamp) {
  * @param {object} newEntry - Updated entry
  * @returns {object} Object where each key maps to { old, new }
  */
-export function diffEntries(oldEntry = {}, newEntry = {}) {
-  const diff = {};
+export function diffEntries(oldEntry = {}, newEntry = {}, options = {}) {
+  const { fieldsToIgnore = [] } = options;
+
+  const differences = {};
   const keys = new Set([
     ...Object.keys(oldEntry || {}),
     ...Object.keys(newEntry || {}),
   ]);
 
   keys.forEach((key) => {
+    if (fieldsToIgnore.includes(key)) return;
     if (oldEntry[key] !== newEntry[key]) {
-      diff[key] = { old: oldEntry[key], new: newEntry[key] };
+      differences[key] = { old: oldEntry[key], new: newEntry[key] };
     }
   });
 
-  return diff;
+  return { differences };
 }

--- a/test/rollback.test.js
+++ b/test/rollback.test.js
@@ -11,15 +11,17 @@ describe('diffEntries', () => {
   test('returns empty object when entries are identical', () => {
     const oldEntry = { a: 1, b: 2 };
     const newEntry = { a: 1, b: 2 };
-    expect(diffEntries(oldEntry, newEntry)).toEqual({});
+    expect(diffEntries(oldEntry, newEntry)).toEqual({ differences: {} });
   });
 
   test('detects changed and added keys', () => {
     const oldEntry = { a: 1, b: 2 };
     const newEntry = { a: 1, b: 3, c: 4 };
     expect(diffEntries(oldEntry, newEntry)).toEqual({
-      b: { old: 2, new: 3 },
-      c: { old: undefined, new: 4 },
+      differences: {
+        b: { old: 2, new: 3 },
+        c: { old: undefined, new: 4 },
+      },
     });
   });
 
@@ -27,7 +29,20 @@ describe('diffEntries', () => {
     const oldEntry = { a: 1, b: 2 };
     const newEntry = { a: 1 };
     expect(diffEntries(oldEntry, newEntry)).toEqual({
-      b: { old: 2, new: undefined },
+      differences: {
+        b: { old: 2, new: undefined },
+      },
+    });
+  });
+
+  test('ignores keys listed in fieldsToIgnore', () => {
+    const oldEntry = { a: 1, b: 2 };
+    const newEntry = { a: 3, b: 4 };
+    const options = { fieldsToIgnore: ['b'] };
+    expect(diffEntries(oldEntry, newEntry, options)).toEqual({
+      differences: {
+        a: { old: 1, new: 3 },
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary
- expand `diffEntries` with options, ignoring unwanted fields
- return changed values wrapped in a `differences` object
- update tests to expect new structure and add ignore-fields case

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857f2dd59e48326a83fd9cd7c54be62