### PR TITLE
Remove unused debugger utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Cellula primaria di Gihary IA – un sistema modulare e auto-evolutivo basato su
 
 The `src/debugger.js` module now provides advanced logging utilities. Call
 `setupDebugger({ verbose: true })` to enable console output and use
-`logState`, `logError` and `captureVar` to record information to `debug.log`.
+`logState` and `logError` to record information to `debug.log`.
 
 ## Ingestion Endpoint
 

--- a/src/debugger.js
+++ b/src/debugger.js
@@ -66,24 +66,6 @@ export function logError(error) {
   }
 }
 
-/**
- * Capture a variable value for later debugging.
- * @param {string} name
- * @param {any} value
- */
-export function captureVar(name, value) {
-  const entry = {
-    timestamp: new Date().toISOString(),
-    type: 'var',
-    name,
-    value,
-  };
-  memoryLogs.push(entry);
-  fs.appendFileSync(logFile, JSON.stringify(entry) + '\n');
-  if (verbose) {
-    console.log(`[VAR] ${name}=`, value);
-  }
-}
 
 /**
  * Retrieve the in-memory log list.
@@ -93,12 +75,3 @@ export function getLogs() {
   return memoryLogs;
 }
 
-/**
- * Perform basic environment checks and return status.
- * @returns {object} - Information about the running environment
- */
-export function checkEnvironment() {
-  const nodeVersion = process.version;
-  const envLoaded = fs.existsSync('.env');
-  return { nodeVersion, envLoaded };
-}


### PR DESCRIPTION
## Summary
- prune obsolete `captureVar` and `checkEnvironment` exports
- update README to reflect available debugger APIs

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68580174bd488326898eb0f12d8d191b