### PR TITLE
Update dev script to ignore TLS locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,13 @@ const mail = `From: Alice <alice@example.com>\nDate: Tue, 3 Oct 2023 10:15:00 +0
 const emails = parseEmail(mail);
 ```
 
+
+## Local development
+
+Quando esegui il server in locale con certificati self-signed potresti dover disattivare i controlli TLS:
+
+```bash
+NODE_TLS_REJECT_UNAUTHORIZED=0 npm run dev
+```
+
+Usa questa impostazione **solo** per i test in locale.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node src/server.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "dev": "next dev",
+    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 next dev",
     "build": "next build",
     "start-frontend": "next start"
   },


### PR DESCRIPTION
## Summary
- ignore TLS errors in `npm run dev` by setting NODE_TLS_REJECT_UNAUTHORIZED=0
- document that this flag is for local usage only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68580181c5bc83268a8275dd59a513d5