### PR TITLE
Refactor dotenv loading

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1,11 +1,9 @@
 // Core module to manage Firestore persistence
 import { initializeApp, applicationDefault } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
-import dotenv from 'dotenv';
+import './env.js';
 import fs from 'fs';
 import path from 'path';
-
-dotenv.config();
 
 const app = initializeApp({
   credential: applicationDefault(),

--- a/src/env.js
+++ b/src/env.js
@@ -1,0 +1,3 @@
+import dotenv from 'dotenv';
+dotenv.config();
+

--- a/src/geminiAnalyzer.js
+++ b/src/geminiAnalyzer.js
@@ -1,7 +1,5 @@
 // Module to interact with Gemini AI for text analysis
-import dotenv from 'dotenv';
-
-dotenv.config();
+import './env.js';
 
 const GEMINI_URL =
   'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent';

--- a/src/server.js
+++ b/src/server.js
@@ -1,12 +1,11 @@
 // Minimal Express server exposing the ingestion endpoint
 import express from 'express';
 import cors from 'cors';
-import dotenv from 'dotenv';
+import './env.js';
 import { ingestText } from './ingestor.js';
 import { logEvent } from './logger.js';
 import { setupDebugger, logState, logError } from './debugger.js';
 
-dotenv.config();
 setupDebugger({ verbose: true });
 
 const app = express();


### PR DESCRIPTION
## Summary
- add a central `src/env.js` to load dotenv once
- import the env loader in server, core, and geminiAnalyzer modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858017020b8832693bd9ea7145c15a3